### PR TITLE
Define additional CSS color variables

### DIFF
--- a/code (28).html
+++ b/code (28).html
@@ -16,11 +16,16 @@
 
             --accent-gold: #B8860B; /* Darker, more antique Gold */
             --accent-gold-light: #DAA520; /* Goldenrod - for highlights */
+            --accent-teal: #008080; /* Teal accent for diagrams */
+            --accent-coral: #FF7F50; /* Coral accent for callouts */
 
             --neutral-900: #121212; /* Near Black */
             --neutral-800: #222222; /* Darkest Gray for text */
             --neutral-700: #383838; /* Main Body Text Gray */
+            --neutral-600: #4F4F4F; /* Secondary text gray */
+            --neutral-500: #666666; /* Muted text gray */
             --neutral-300: #CCCCCC; /* Light Gray for lines/borders */
+            --neutral-200: #E5E5E5; /* Very light gray for backgrounds */
             --neutral-100: #F7F7F7; /* Very Light Off-White for page backgrounds */
             --neutral-50: #FFFFFF;  /* Pure White for contrast elements */
 


### PR DESCRIPTION
## Summary
- define accent-teal and accent-coral in CSS
- add missing neutral gray variables for styling

## Testing
- `git status --short`